### PR TITLE
Resolves #13. Now resolves the longest alias match

### DIFF
--- a/test/specs.js
+++ b/test/specs.js
@@ -109,4 +109,20 @@ describe('module-alias', function () {
       done()
     })
   })
+
+  it('should match longest alias first', function () {
+    moduleAlias.addAliases({
+      'react-dom': path.join(__dirname, 'src/bar/baz'),
+      'react-dom/server': path.join(__dirname, 'src/foo')
+    })
+
+    var bar, src
+    try {
+      bar = require('react-dom')
+      src = require('react-dom/server')
+    } catch (e) {}
+
+    expect(bar).to.equal('Hello from baz')
+    expect(src).to.equal('Hello from foo')
+  })
 })


### PR DESCRIPTION
Given aliases such as:
```
"react-dom": "preact-compat-enzyme",
"react-dom/server": "preact-render-to-string",
```

Previously, if one attempted `require('react-dom/server')`, the library would accept `react-dom` as the appropriate alias to use. This PR resolves that by sorting the alias names and then traversing that list to look for the longest match.