### PR TITLE
Support import settings from different section of package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ function init (options) {
   // Import aliases
   //
 
-  var aliases = npmPackage._moduleAliases || {}
+  var aliases = npmPackage[options.moduleAliases || "_moduleAliases"] || {}
 
   for (var alias in aliases) {
     if (aliases[alias][0] !== '/') {
@@ -166,9 +166,10 @@ function init (options) {
   //
   // Register custom module directories (like node_modules)
   //
+  var moduleDirectories = npmPackage[options.moduleDirectories || "_moduleDirectories"];
 
-  if (npmPackage._moduleDirectories instanceof Array) {
-    npmPackage._moduleDirectories.forEach(function (dir) {
+  if (moduleDirectories instanceof Array) {
+      moduleDirectories.forEach(function (dir) {
       if (dir === 'node_modules') return
 
       var modulePath = nodePath.join(base, dir)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "module-alias",
   "description": "Create aliases of directories and register custom module paths in NodeJS like a boss!",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": {
     "name": "Nick Gavrilov",
     "email": "artnikpro@gmail.com"

--- a/test/specs.js
+++ b/test/specs.js
@@ -99,6 +99,18 @@ describe('module-alias', function () {
     expect(someModule).to.equal('Hello from some-module')
   })
 
+  it('should import settings from different section of package.json', function () {
+      moduleAlias({
+          base: path.join(__dirname, 'src'),
+          moduleAliases: "_testModuleAliases"
+      })
+      var test
+      try {
+          test = require('@test')
+      } catch (e) {}
+      expect(test).to.equal('Hello from test')
+  })
+
   it('should support forked modules', function () {
     expect(require('hello-world-classic')).to.be.function
   })

--- a/test/src/package.json
+++ b/test/src/package.json
@@ -6,5 +6,8 @@
     "@foo": "foo/index.js",
     "@bar": "bar",
     "some/foo": "foo"
+  },
+  "_testModuleAliases": {
+    "@test": "test/index.js"
   }
 }

--- a/test/src/test/index.js
+++ b/test/src/test/index.js
@@ -1,0 +1,1 @@
+module.exports = 'Hello from test'


### PR DESCRIPTION
Our project uses sophisticated path mappings, which works great with `require('module-alias/register');` and `_moduleAliases` in package.json in production code.

But our unit tests build produce slightly different paths and we need different '_moduleAliases' configuration.

Currently problem is solved programmatically via `.addAliases` in special file `test-module-alias.js`, which is required in every test file.
The problem is requiring special file itself, which may look crazy like `require('../../../test-module-alias');`

This pull request provides ability to import alias settings from different section of package.json. 
Unit test added.