### PR TITLE
Add default init behavior: look for package.json in process.cwd()

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,22 +138,25 @@ function init (options) {
 
   options = options || {}
 
-  // There is probably 99% chance that the project root directory in located
-  // above the node_modules directory,
-  // Or that package.json is in the node process' current working directory (when
-  // running a package manager script, e.g. `yarn start` / `npm run start`)
-  var candidatePackagePath = [
-    (options.base || '').replace(/\/package\.json$/, ''),
-    nodePath.join(__dirname, '../..'),
-    process.cwd()
-  ]
+
+  var candidatePackagePaths
+  if(options.base) {
+    candidatePackagePaths = [options.base.replace(/\/package\.json$/, '')]
+  } else {
+    // There is probably 99% chance that the project root directory in located
+    // above the node_modules directory,
+    // Or that package.json is in the node process' current working directory (when
+    // running a package manager script, e.g. `yarn start` / `npm run start`)
+    candidatePackagePaths = [nodePath.join(__dirname, '../..'), process.cwd()]
+  }
 
   var npmPackage
   var base
-  for (var i in candidatePackagePath) {
+  for (var i in candidatePackagePaths) {
     try {
-      base = candidatePackagePath[i]
-      npmPackage = require(base + '/package.json')
+      base = candidatePackagePaths[i]
+
+      npmPackage = require(nodePath.join(base, 'package.json'))
       break
     } catch (e) {
       // noop
@@ -161,7 +164,8 @@ function init (options) {
   }
 
   if (typeof npmPackage !== 'object') {
-    throw new Error('Unable to read any of [' + candidatePackagePath.map(function(path) { return base + '/package.json'}).join(', ')  + ']')
+    var pathString = candidatePackagePaths.join('\n, ')
+    throw new Error('Unable to find package.json in any of:\n[' + pathString  + ']')
   }
 
   //

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ function init (options) {
 
   var candidatePackagePaths
   if(options.base) {
-    candidatePackagePaths = [options.base.replace(/\/package\.json$/, '')]
+    candidatePackagePaths = [nodePath.resolve(options.base.replace(/\/package\.json$/, ''))]
   } else {
     // There is probably 99% chance that the project root directory in located
     // above the node_modules directory,
@@ -164,7 +164,7 @@ function init (options) {
   }
 
   if (typeof npmPackage !== 'object') {
-    var pathString = candidatePackagePaths.join('\n, ')
+    var pathString = candidatePackagePaths.join(',\n')
     throw new Error('Unable to find package.json in any of:\n[' + pathString  + ']')
   }
 

--- a/index.js
+++ b/index.js
@@ -138,9 +138,8 @@ function init (options) {
 
   options = options || {}
 
-
   var candidatePackagePaths
-  if(options.base) {
+  if (options.base) {
     candidatePackagePaths = [nodePath.resolve(options.base.replace(/\/package\.json$/, ''))]
   } else {
     // There is probably 99% chance that the project root directory in located
@@ -165,7 +164,7 @@ function init (options) {
 
   if (typeof npmPackage !== 'object') {
     var pathString = candidatePackagePaths.join(',\n')
-    throw new Error('Unable to find package.json in any of:\n[' + pathString  + ']')
+    throw new Error('Unable to find package.json in any of:\n[' + pathString + ']')
   }
 
   //

--- a/test/specs.js
+++ b/test/specs.js
@@ -78,25 +78,47 @@ describe('module-alias', function () {
     expect(something).to.equal('Hello from foo')
   })
 
-  it('should import settings from package.json', function () {
-    moduleAlias({
-      base: path.join(__dirname, 'src')
+  describe('importing settings from package.json', () => {
+    var baseWorkingDirectory
+    beforeEach(function() {
+      baseWorkingDirectory = process.cwd()
     })
 
-    var src, foo, baz, some, someModule
-    try {
-      src = require('@src/foo')
-      foo = require('@foo')
-      baz = require('@bar/baz')
-      some = require('some/foo')
-      someModule = require('some-module')
-    } catch (e) {}
+    afterEach(function(){
+      process.chdir(baseWorkingDirectory)
+    })
 
-    expect(src).to.equal('Hello from foo')
-    expect(foo).to.equal('Hello from foo')
-    expect(baz).to.equal('Hello from baz')
-    expect(some).to.equal('Hello from foo')
-    expect(someModule).to.equal('Hello from some-module')
+    function expectAliasesToBeImported() {
+      var src, foo, baz, some, someModule
+      try {
+        src = require('@src/foo')
+        foo = require('@foo')
+        baz = require('@bar/baz')
+        some = require('some/foo')
+        someModule = require('some-module')
+      } catch (e) {}
+
+      expect(src).to.equal('Hello from foo')
+      expect(foo).to.equal('Hello from foo')
+      expect(baz).to.equal('Hello from baz')
+      expect(some).to.equal('Hello from foo')
+      expect(someModule).to.equal('Hello from some-module')
+    }
+
+    it('should import settings from user-defined base path', function () {
+      moduleAlias({
+        base: path.join(__dirname, 'src')
+      })
+
+      expectAliasesToBeImported()
+    })
+
+    it('should import default settings from process.cwd()', function() {
+      process.chdir(path.join(__dirname, 'src'))
+      moduleAlias()
+
+      expectAliasesToBeImported()
+    })
   })
 
   it('should support forked modules', function () {

--- a/test/specs.js
+++ b/test/specs.js
@@ -78,17 +78,17 @@ describe('module-alias', function () {
     expect(something).to.equal('Hello from foo')
   })
 
-  describe('importing settings from package.json', function() {
+  describe('importing settings from package.json', function () {
     var baseWorkingDirectory
-    beforeEach(function() {
+    beforeEach(function () {
       baseWorkingDirectory = process.cwd()
     })
 
-    afterEach(function(){
+    afterEach(function () {
       process.chdir(baseWorkingDirectory)
     })
 
-    function expectAliasesToBeImported() {
+    function expectAliasesToBeImported () {
       var src, foo, baz, some, someModule
       try {
         src = require('@src/foo')
@@ -113,7 +113,7 @@ describe('module-alias', function () {
       expectAliasesToBeImported()
     })
 
-    it('should import default settings from process.cwd()', function() {
+    it('should import default settings from process.cwd()', function () {
       process.chdir(path.join(__dirname, 'src'))
       moduleAlias()
 

--- a/test/specs.js
+++ b/test/specs.js
@@ -78,7 +78,7 @@ describe('module-alias', function () {
     expect(something).to.equal('Hello from foo')
   })
 
-  describe('importing settings from package.json', () => {
+  describe('importing settings from package.json', function() {
     var baseWorkingDirectory
     beforeEach(function() {
       baseWorkingDirectory = process.cwd()

--- a/test/src/node_modules/module-alias/.keep
+++ b/test/src/node_modules/module-alias/.keep
@@ -1,0 +1,1 @@
+# keep me for folder


### PR DESCRIPTION
We ran an issue with the default require('module-alias/register') because the node_modules in our prod environment was soft-linked to the current working directory.

Trying to load package.json from Node's current working directory does the trick, because we are running the app from a package manager ; so we added this as a possibility the init script will try out.

The no-argument init relies on the position of index.js in the filesystem, so it's tricky to test. And the default behavior currently has no test covering it - so we did not add a test.

Lines 147 and 148 seem redundant, you might want to have a look.