### PR TITLE
Retrieve Alias Path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea/*

--- a/index.js
+++ b/index.js
@@ -183,9 +183,23 @@ function init (options) {
   }
 }
 
+// Retrieve a path by specifying a registered alias
+function getAliasPath(alias) {
+    if (!moduleAliases[alias]) {
+        throw new Error('[' + alias + ']: alias does not exist');
+    }
+
+    if (typeof alias === 'string') {
+        return moduleAliases[alias];
+    } else {
+        throw new Error('[' + alias + ']: Is not of type string');
+    }
+}
+
 module.exports = init
 module.exports.addPath = addPath
 module.exports.addAlias = addAlias
 module.exports.addAliases = addAliases
 module.exports.isPathMatchesAlias = isPathMatchesAlias
 module.exports.reset = reset
+module.exports.getAliasPath = getAliasPath

--- a/index.js
+++ b/index.js
@@ -185,15 +185,15 @@ function init (options) {
 
 // Retrieve a path by specifying a registered alias
 function getAliasPath(alias) {
+    if (typeof alias !== 'string') {
+        throw new Error('[' + alias + ']: is not of type string');
+    }
+
     if (!moduleAliases[alias]) {
         throw new Error('[' + alias + ']: alias does not exist');
     }
 
-    if (typeof alias === 'string') {
-        return moduleAliases[alias];
-    } else {
-        throw new Error('[' + alias + ']: Is not of type string');
-    }
+    return moduleAliases[alias];
 }
 
 module.exports = init

--- a/index.js
+++ b/index.js
@@ -186,11 +186,11 @@ function init (options) {
 // Retrieve a path by specifying a registered alias
 function getAliasPath(alias) {
     if (typeof alias !== 'string') {
-        throw new Error('[' + alias + ']: is not of type string');
+        throw new Error('"' + alias + '": is not of type string');
     }
 
     if (!moduleAliases[alias]) {
-        throw new Error('[' + alias + ']: alias does not exist');
+        throw new Error('"' + alias + '": alias does not exist');
     }
 
     return moduleAliases[alias];

--- a/test/specs.js
+++ b/test/specs.js
@@ -175,28 +175,26 @@ describe('Custom handler function', function () {
       .to.throw('[module-alias] Expecting custom handler function to return path.')
   })
 
-    it('should return a path matching the alias', function () {
-        var expected = path.join(__dirname, 'src/bar/baz');
-        moduleAlias.addAlias('@root', expected);
+  it('should return a path matching the alias', function () {
+      var expected = path.join(__dirname, 'src/bar/baz');
+      moduleAlias.addAlias('@root', expected);
 
-        var rootPath = moduleAlias.getAliasPath('@root');
-        expect(rootPath)
-            .to.equal(expected);
-    })
+      var rootPath = moduleAlias.getAliasPath('@root');
+      expect(rootPath)
+          .to.equal(expected);
+  })
 
-    it('should throw when alias does not exist', function () {
-        var expected = '[@randomPath]: alias does not exist';
-        expect(function () {
-            moduleAlias.getAliasPath('@randomPath');
-        })
-            .to.throw(expected);
-    })
+  it('should throw when alias does not exist', function () {
+      var expected = '[@randomPath]: alias does not exist';
+      expect(function () {
+          moduleAlias.getAliasPath('@randomPath');
+      }).to.throw(expected);
+  })
 
-    it('should throw when alias is not a string', function () {
-        var expected = '[123]: is not of type string';
-        expect(function () {
-            moduleAlias.getAliasPath(123);
-        })
-            .to.throw(expected);
-    })
+  it('should throw when alias is not a string', function () {
+      var expected = '[123]: is not of type string';
+      expect(function () {
+          moduleAlias.getAliasPath(123);
+      }).to.throw(expected);
+  })
 })

--- a/test/specs.js
+++ b/test/specs.js
@@ -180,8 +180,7 @@ describe('Custom handler function', function () {
       moduleAlias.addAlias('@root', expected);
 
       var rootPath = moduleAlias.getAliasPath('@root');
-      expect(rootPath)
-          .to.equal(expected);
+      expect(rootPath).to.equal(expected);
   })
 
   it('should throw when alias does not exist', function () {
@@ -192,7 +191,7 @@ describe('Custom handler function', function () {
   })
 
   it('should throw when alias is not a string', function () {
-      var expected = '[123]: is not of type string';
+      var expected = '"123": is not of type string';
       expect(function () {
           moduleAlias.getAliasPath(123);
       }).to.throw(expected);

--- a/test/specs.js
+++ b/test/specs.js
@@ -174,4 +174,29 @@ describe('Custom handler function', function () {
     })
       .to.throw('[module-alias] Expecting custom handler function to return path.')
   })
+
+    it('should return a path matching the alias', function () {
+        var expected = path.join(__dirname, 'src/bar/baz');
+        moduleAlias.addAlias('@root', expected);
+
+        var rootPath = moduleAlias.getAliasPath('@root');
+        expect(rootPath)
+            .to.equal(expected);
+    })
+
+    it('should throw when alias does not exist', function () {
+        var expected = '[@randomPath]: alias does not exist';
+        expect(function () {
+            moduleAlias.getAliasPath('@randomPath');
+        })
+            .to.throw(expected);
+    })
+
+    it('should throw when alias is not a string', function () {
+        var expected = '[123]: is not of type string';
+        expect(function () {
+            moduleAlias.getAliasPath(123);
+        })
+            .to.throw(expected);
+    })
 })


### PR DESCRIPTION
## Change
Added a method that will take a alias as a string, validate that it exists in the moduleAliase's object. and that it is of type string. This will then return the relevant path for that alias.

## Reason
We came across the need in our express/typescript environment to create dynamic imports as well as fs read processes. These file paths are not imported and change depending on the environment. This will you to use the registered aliases outside of a import or require.