### PR TITLE
Adding separate config file(module.alias.config.js) for module aliases.

### DIFF
--- a/test/specs.js
+++ b/test/specs.js
@@ -125,7 +125,7 @@ describe('module-alias', function () {
       })
     })
   })
-  
+
   describe('importing settings from package.json', function () {
     function expectAliasesToBeImported () {
       var src, foo, baz, some, someModule
@@ -197,7 +197,6 @@ describe('module-alias', function () {
       })
     })
   })
-
 
   it('should support forked modules', function () {
     expect(typeof require('hello-world-classic')).to.equal('function')

--- a/test/specs.js
+++ b/test/specs.js
@@ -81,6 +81,51 @@ describe('module-alias', function () {
     expect(something).to.equal('Hello from foo')
   })
 
+  describe('importing settings from module.alias.config.js', function () {
+    function expectAliasesToBeImported () {
+      var foo2, bar2
+      try {
+        foo2 = require('@foo2')
+        bar2 = require('@bar2')
+      } catch (e) {
+      }
+      expect(foo2).to.equal('Hello from foo2')
+      expect(bar2).to.equal('Hello from bar2')
+    }
+
+    describe('when base working directory is process.cwd()', function () {
+      var baseWorkingDirectory
+      beforeEach(function () {
+        baseWorkingDirectory = process.cwd()
+      })
+
+      afterEach(function () {
+        process.chdir(baseWorkingDirectory)
+      })
+
+      it('should import settings from user-defined base path', function () {
+        moduleAlias({
+          base: path.join(__dirname, 'src')
+        })
+
+        expectAliasesToBeImported()
+      })
+
+      it('should import default settings from process.cwd()/module.alias.config.js', function () {
+        process.chdir(path.join(__dirname, 'src'))
+        moduleAlias()
+        expectAliasesToBeImported()
+      })
+
+      it('should import default settings from config filename defined in environment variable(process.evn.ALIAS_FILENAME)', function () {
+        process.env.ALIAS_FILENAME = 'alias.custom.config.js'
+        process.chdir(path.join(__dirname, 'src'))
+        moduleAlias()
+        expectAliasesToBeImported()
+      })
+    })
+  })
+  
   describe('importing settings from package.json', function () {
     function expectAliasesToBeImported () {
       var src, foo, baz, some, someModule
@@ -152,6 +197,7 @@ describe('module-alias', function () {
       })
     })
   })
+
 
   it('should support forked modules', function () {
     expect(typeof require('hello-world-classic')).to.equal('function')

--- a/test/src/alias.custom.config.js
+++ b/test/src/alias.custom.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  _moduleDirectories: ['node_modules_custom'],
+  _moduleAliases: {
+    '@foo2': 'foo2/index.js',
+    '@bar2': 'bar2/index.js'
+  }
+}

--- a/test/src/bar2/index.js
+++ b/test/src/bar2/index.js
@@ -1,0 +1,1 @@
+module.exports = 'Hello from bar2'

--- a/test/src/foo2/index.js
+++ b/test/src/foo2/index.js
@@ -1,0 +1,1 @@
+module.exports = 'Hello from foo2'

--- a/test/src/module.alias.config.js
+++ b/test/src/module.alias.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  _moduleDirectories: ['node_modules_custom'],
+  _moduleAliases: {
+    '@foo2': 'foo2/index.js',
+    '@bar2': 'bar2/index.js'
+  }
+}


### PR DESCRIPTION
To keep both package.json and code clean, we can add a file which will contains all modules alias for better management of project. I named it module.alias.config.js which is default. But user can use different name by process.env.process.env.ALIAS_FILENAME.I have added some test cases also. Please review code and let me know about further changes. Thanks. :) 

module.alias.config.js
`
module.exports = {
  _moduleDirectories: ['node_modules_custom'],
  _moduleAliases: {
    '@foo2': 'foo2/index.js',
    '@bar2': 'bar2/index.js'
  }
}
`
