### PR TITLE
Fix "reset": also reset module alias names

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,6 +134,7 @@ function reset () {
 
   modulePaths = []
   moduleAliases = {}
+  moduleAliasNames = []
 }
 
 /**


### PR DESCRIPTION
When working on some tests I had weird issues: tests started failing when I added a describe block.

Several things where happening:
1. We import TWO versions of module-alias in the tests. One for all tests, and one for the specific test `when module-alias package is nested (looking up __dirname/../../)`. Each of these modules registers their own handlers, and have to be reset separately.
2. Also, "reset" did not clear the moduleAliasNames, which confused module-alias to think an alias was registered when it was actually not in the moduleAliases object.

As part of this PR, I also cleaned up the tests:
- Import module-alias once for all tests, not before every test
- Move the `Custom handler function` describe block within the test suite: it reference the "moduleAlias" variable which is initialized by the "before" block. Also moved "moduleAlias" within the top-level describe. We could have imported it directly above the describe, but since it's the thing under test, that looks more explicit to me.