### PR TITLE
Make module-alias work in cli mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,14 +82,15 @@ function addPath (path) {
   if (modulePaths.indexOf(path) === -1) {
     modulePaths.push(path)
     // Enable the search path for the current top-level module
-    if (require.main) {
-      addPathHelper(path, require.main.paths)
+    var mainModule = getMainModule()
+    if (mainModule) {
+      addPathHelper(path, mainModule.paths)
     }
     parent = module.parent
 
     // Also modify the paths of the module that was used to load the
     // app-module-paths module and all of it's parents
-    while (parent && parent !== require.main) {
+    while (parent && parent !== mainModule) {
       addPathHelper(path, parent.paths)
       parent = parent.parent
     }
@@ -115,10 +116,12 @@ function addAlias (alias, target) {
  * The function is undocumented and for testing purposes only
  */
 function reset () {
+  var mainModule = getMainModule()
+
   // Reset all changes in paths caused by addPath function
   modulePaths.forEach(function (path) {
-    if (require.main) {
-      removePathHelper(path, require.main.paths)
+    if (mainModule) {
+      removePathHelper(path, mainModule.paths)
     }
 
     // Delete from require.cache if the module has been required before.
@@ -130,7 +133,7 @@ function reset () {
     })
 
     var parent = module.parent
-    while (parent && parent !== require.main) {
+    while (parent && parent !== mainModule) {
       removePathHelper(path, parent.paths)
       parent = parent.parent
     }
@@ -207,6 +210,10 @@ function init (options) {
       addPath(modulePath)
     })
   }
+}
+
+function getMainModule () {
+  return require.main._simulateRepl ? undefined : require.main
 }
 
 module.exports = init

--- a/index.js
+++ b/index.js
@@ -82,7 +82,9 @@ function addPath (path) {
   if (modulePaths.indexOf(path) === -1) {
     modulePaths.push(path)
     // Enable the search path for the current top-level module
-    addPathHelper(path, require.main.paths)
+    if (require.main) {
+      addPathHelper(path, require.main.paths)
+    }
     parent = module.parent
 
     // Also modify the paths of the module that was used to load the
@@ -115,7 +117,9 @@ function addAlias (alias, target) {
 function reset () {
   // Reset all changes in paths caused by addPath function
   modulePaths.forEach(function (path) {
-    removePathHelper(path, require.main.paths)
+    if (require.main) {
+      removePathHelper(path, require.main.paths)
+    }
 
     // Delete from require.cache if the module has been required before.
     // This is required for node >= 11

--- a/test/specs.js
+++ b/test/specs.js
@@ -158,6 +158,24 @@ describe('module-alias', function () {
     })
   })
 
+  context('when used from the REPL', function () {
+    before(function () {
+      require.main._simulateRepl = true
+    })
+
+    after(function () {
+      delete require.main._simulateRepl
+    })
+
+    it('should addPath', function () {
+      moduleAlias.addPath('some-path')
+    })
+
+    it('should reset', function () {
+      moduleAlias.reset()
+    })
+  })
+
   it('should support forked modules', function () {
     expect(typeof require('hello-world-classic')).to.equal('function')
   })


### PR DESCRIPTION
Fixes #65 

It builds on top of @dgobaud's PR, and adds tests.

There might be some rare cases when you want to use module-alias while running in a REPL (e.g. `$ node -i`). In that case, `require.main` is undefined.

This means introducing a way of having "require.main" undefined in our module. The require function is different between the test module and the module under test, so we can't just do `require.main = null` in the test function, as it won't affect the "require" function of the prod code. So we need to introduce a helper function for evaluating require.main, and inject a flag in the test module when running the tests.

