### PR TITLE
Ensure require.main is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,7 +213,8 @@ function init (options) {
 }
 
 function getMainModule () {
-  return require.main._simulateRepl ? undefined : require.main
+  var main = require.main
+  return main && main._simulateRepl ? undefined : main
 }
 
 module.exports = init


### PR DESCRIPTION
In electron environment require.main can be undefined.
This make sure this function does not throw an Error