### PR TITLE
change the default package.json to the current dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ function init (options) {
     // above the node_modules directory,
     // Or that package.json is in the node process' current working directory (when
     // running a package manager script, e.g. `yarn start` / `npm run start`)
-    candidatePackagePaths = [nodePath.join(__dirname, '../..'), process.cwd()]
+    candidatePackagePaths = [process.cwd(), nodePath.join(__dirname, '../..')]
   }
 
   var npmPackage

--- a/test/specs.js
+++ b/test/specs.js
@@ -151,6 +151,8 @@ describe('module-alias', function () {
       })
 
       it('should import default settings from ../../package.json', function () {
+        process.chdir(moduleAliasDir)
+
         linkedModuleAlias()
 
         expectAliasesToBeImported()

--- a/test/src/node_modules/module-alias/package.json
+++ b/test/src/node_modules/module-alias/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "test-app",
+  "_moduleDirectories": ["../../node_modules_custom"],
+  "_moduleAliases": {
+    "@src": "../..",
+    "@foo": "../../foo/index.js",
+    "@bar": "../../bar",
+    "some/foo": "../../foo"
+  }
+}


### PR DESCRIPTION
For solving the issue: https://github.com/ilearnio/module-alias/issues/120. Maybe that the default package.json is from current directory is friendly to users.