### PR TITLE
Docs: Add example to point jest to a single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ Unfortunately, `module-alias` itself would not work from Jest due to a custom be
 "jest": {
   "moduleNameMapper": {
     "@root/(.*)": "<rootDir>/$1",
-    "@client/(.*)": "<rootDir>/src/client/$1"
+    "@client/(.*)": "<rootDir>/src/client/$1",
+    "@server": "<rootDir>/server.js" // Pointing jest to a single file not a directory.
   },
 }
 ```


### PR DESCRIPTION
Add example to point jest to a single file not a module.