### PR TITLE
feat: add ESM support via Node.js loader hooks

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,20 +11,19 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-
+  test-legacy:
+    # CJS-only tests for older Node versions
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 17.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: node -v
@@ -32,3 +31,22 @@ jobs:
     - run: npm install
     - run: npm run testonly
 
+  test-esm:
+    # CJS + ESM tests for Node 18+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: node -v
+    - run: npm -v
+    - run: npm install
+    - run: npm run test:all

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ npm i --save module-alias
 
 ## Usage
 
+### CommonJS (require)
+
 Add your custom configuration to your `package.json` (in your application's root)
 
 ```js
@@ -79,6 +81,45 @@ import module from '@root/some-module'
 import veryDeepModule from '@deep/my-module'
 import customModule from 'my_private_module' // module from `node_modules_custom` directory
 ```
+
+### ES Modules (import) - Node 18+
+
+For native ES modules, use the `--import` flag:
+
+```bash
+node --import module-alias/register ./app.mjs
+```
+
+Your `package.json` configuration works the same way:
+
+```json
+{
+  "_moduleAliases": {
+    "@lib": "src/lib",
+    "@utils": "src/utils"
+  }
+}
+```
+
+Then in your ES module:
+
+```js
+import { something } from '@lib/something.js'
+```
+
+**Node Version Support:**
+
+| Node Version | API Used |
+|--------------|----------|
+| 22.15+ | `module.registerHooks()` (sync, recommended) |
+| 18.19 - 22.14 | `module.register()` (async) |
+| < 18.19 | Not supported for ESM |
+
+**ESM Limitations:**
+
+- Requires `--import` flag - cannot be imported at runtime like CJS
+- Programmatic `addAlias()` not available before app starts
+- Function-based resolvers must be configured via the loader API
 
 ## Advanced usage
 

--- a/esm-loader.mjs
+++ b/esm-loader.mjs
@@ -1,0 +1,148 @@
+// ESM loader for module-alias
+// Provides resolve hooks for ES modules
+
+import { readFileSync, existsSync, statSync } from 'node:fs'
+import { join, resolve as pathResolve, dirname } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+let aliases = {}
+let moduleDirectories = []
+let base = process.cwd()
+let initialized = false
+
+export function init (options = {}) {
+  if (initialized) return
+
+  const thisDir = dirname(fileURLToPath(import.meta.url))
+  const candidatePaths = options.base
+    ? [pathResolve(options.base)]
+    : [join(thisDir, '../..'), process.cwd()]
+
+  let pkg
+  for (const candidate of candidatePaths) {
+    try {
+      pkg = JSON.parse(readFileSync(join(candidate, 'package.json'), 'utf8'))
+      base = candidate
+      break
+    } catch (e) {
+      // Continue to next candidate
+    }
+  }
+
+  if (!pkg) {
+    console.warn('[module-alias] Unable to find package.json in:', candidatePaths.join(', '))
+    initialized = true
+    return
+  }
+
+  // Load _moduleAliases
+  const pkgAliases = pkg._moduleAliases || {}
+  for (const alias in pkgAliases) {
+    const target = pkgAliases[alias]
+    aliases[alias] = target.startsWith('/') ? target : join(base, target)
+  }
+
+  // Load _moduleDirectories
+  if (Array.isArray(pkg._moduleDirectories)) {
+    moduleDirectories = pkg._moduleDirectories
+      .filter(d => d !== 'node_modules')
+      .map(d => join(base, d))
+  }
+
+  initialized = true
+}
+
+export function isPathMatchesAlias (path, alias) {
+  // Matching /^alias(\/|$)/
+  if (path.indexOf(alias) === 0) {
+    if (path.length === alias.length) return true
+    if (path[alias.length] === '/') return true
+  }
+  return false
+}
+
+export function resolveAlias (specifier, parentURL) {
+  init() // Ensure initialized
+
+  // Sort aliases by length (longest first) for correct matching
+  const sortedAliases = Object.keys(aliases).sort((a, b) => b.length - a.length)
+
+  for (const alias of sortedAliases) {
+    if (isPathMatchesAlias(specifier, alias)) {
+      const target = aliases[alias]
+
+      // Function-based resolver
+      if (typeof target === 'function') {
+        const parentPath = parentURL ? fileURLToPath(parentURL) : process.cwd()
+        const result = target(parentPath, specifier, alias)
+        if (!result || typeof result !== 'string') {
+          throw new Error('[module-alias] Custom handler must return path')
+        }
+        return result
+      }
+
+      // String path - join target with remainder of specifier
+      return join(target, specifier.slice(alias.length))
+    }
+  }
+
+  // Check moduleDirectories
+  for (const dir of moduleDirectories) {
+    const modulePath = join(dir, specifier)
+    // Check for directory with index.mjs/index.js
+    if (existsSync(join(modulePath, 'index.mjs'))) {
+      return join(modulePath, 'index.mjs')
+    }
+    if (existsSync(join(modulePath, 'index.js'))) {
+      return join(modulePath, 'index.js')
+    }
+    // Check for file with extension
+    if (existsSync(modulePath + '.mjs')) {
+      return modulePath + '.mjs'
+    }
+    if (existsSync(modulePath + '.js')) {
+      return modulePath + '.js'
+    }
+    // Check for exact file
+    if (existsSync(modulePath) && !statSync(modulePath).isDirectory()) {
+      return modulePath
+    }
+  }
+
+  return null
+}
+
+export function addAlias (alias, target) {
+  aliases[alias] = target
+}
+
+export function addAliases (aliasMap) {
+  for (const alias in aliasMap) {
+    addAlias(alias, aliasMap[alias])
+  }
+}
+
+export function reset () {
+  aliases = {}
+  moduleDirectories = []
+  base = process.cwd()
+  initialized = false
+}
+
+// For Node 18-21: async loader hooks
+export async function resolve (specifier, context, nextResolve) {
+  const resolved = resolveAlias(specifier, context.parentURL)
+  if (resolved) {
+    // If absolute path, convert to file URL
+    if (resolved.startsWith('/')) {
+      return { url: pathToFileURL(resolved).href, shortCircuit: true }
+    }
+    // Otherwise let Node resolve it (could be npm package)
+    return nextResolve(resolved, context)
+  }
+  return nextResolve(specifier, context)
+}
+
+export async function initialize (data) {
+  init(data || {})
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test": "npm run lint && npm run testonly",
     "testonly": "NODE_ENV=test mocha test/specs.js",
     "testonly-watch": "NODE_ENV=test mocha -w test/specs.js",
+    "test:esm": "NODE_ENV=test mocha test/esm/unit.mjs test/esm/integration.js",
+    "test:all": "npm run testonly && npm run test:esm",
     "lint": "standard"
   },
   "bugs": {
@@ -25,9 +27,21 @@
   ],
   "license": "MIT",
   "main": "index.js",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "import": "./index.js"
+    },
+    "./register": {
+      "require": "./register.js",
+      "import": "./register.mjs"
+    }
+  },
   "files": [
     "index.js",
     "register.js",
+    "register.mjs",
+    "esm-loader.mjs",
     "README.md",
     "LICENSE"
   ],

--- a/register.mjs
+++ b/register.mjs
@@ -1,0 +1,31 @@
+// ESM entry point for module-alias
+// Usage: node --import module-alias/register ./app.mjs
+
+import { register } from 'node:module'
+
+// Check Node version for registerHooks support (22.15+)
+const [major, minor] = process.versions.node.split('.').map(Number)
+const hasRegisterHooks = major > 22 || (major === 22 && minor >= 15)
+
+if (hasRegisterHooks) {
+  // Node 22.15+ - use synchronous hooks on main thread
+  const { registerHooks } = await import('node:module')
+  const { resolveAlias, init } = await import('./esm-loader.mjs')
+
+  init()
+
+  registerHooks({
+    resolve (specifier, context, nextResolve) {
+      const resolved = resolveAlias(specifier, context.parentURL)
+      if (resolved) {
+        return nextResolve(resolved, context)
+      }
+      return nextResolve(specifier, context)
+    }
+  })
+} else {
+  // Node 18.19 - 22.14 - use async hooks via worker thread
+  register('./esm-loader.mjs', {
+    parentURL: import.meta.url
+  })
+}

--- a/test/esm/fixtures/basic/app.mjs
+++ b/test/esm/fixtures/basic/app.mjs
@@ -1,0 +1,2 @@
+import { message } from '@lib/foo.mjs'
+console.log(message)

--- a/test/esm/fixtures/basic/package.json
+++ b/test/esm/fixtures/basic/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "esm-basic-test",
+  "type": "module",
+  "_moduleAliases": {
+    "@lib": "src/lib"
+  }
+}

--- a/test/esm/fixtures/basic/src/lib/foo.mjs
+++ b/test/esm/fixtures/basic/src/lib/foo.mjs
@@ -1,0 +1,1 @@
+export const message = 'Hello from foo'

--- a/test/esm/fixtures/module-dirs/app.mjs
+++ b/test/esm/fixtures/module-dirs/app.mjs
@@ -1,0 +1,2 @@
+import { message } from 'mymodule'
+console.log(message)

--- a/test/esm/fixtures/module-dirs/custom_modules/mymodule/index.mjs
+++ b/test/esm/fixtures/module-dirs/custom_modules/mymodule/index.mjs
@@ -1,0 +1,1 @@
+export const message = 'Hello from custom module'

--- a/test/esm/fixtures/module-dirs/package.json
+++ b/test/esm/fixtures/module-dirs/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "esm-module-dirs-test",
+  "type": "module",
+  "_moduleDirectories": ["custom_modules"]
+}

--- a/test/esm/integration.js
+++ b/test/esm/integration.js
@@ -1,0 +1,44 @@
+/* eslint-env mocha */
+var expect = require('chai').expect
+var execSync = require('child_process').execSync
+var path = require('path')
+var semver = require('semver')
+
+describe('ESM Integration', function () {
+  // Skip all ESM tests on Node < 18.19.0
+  if (semver.lt(process.version, '18.19.0')) {
+    console.log('Skipping ESM integration tests on Node ' + process.version)
+    return
+  }
+
+  var fixturesDir = path.join(__dirname, 'fixtures')
+  var moduleAliasRoot = path.join(__dirname, '../..')
+
+  describe('basic alias', function () {
+    it('should resolve alias in ESM with --import flag', function () {
+      var fixture = path.join(fixturesDir, 'basic')
+      var registerPath = path.join(moduleAliasRoot, 'register.mjs')
+
+      var result = execSync(
+        'node --import ' + registerPath + ' app.mjs',
+        { cwd: fixture, encoding: 'utf8' }
+      )
+
+      expect(result.trim()).to.equal('Hello from foo')
+    })
+  })
+
+  describe('moduleDirectories', function () {
+    it('should resolve modules from custom directories', function () {
+      var fixture = path.join(fixturesDir, 'module-dirs')
+      var registerPath = path.join(moduleAliasRoot, 'register.mjs')
+
+      var result = execSync(
+        'node --import ' + registerPath + ' app.mjs',
+        { cwd: fixture, encoding: 'utf8' }
+      )
+
+      expect(result.trim()).to.equal('Hello from custom module')
+    })
+  })
+})

--- a/test/esm/unit.mjs
+++ b/test/esm/unit.mjs
@@ -1,0 +1,92 @@
+/* eslint-env mocha */
+import chai from 'chai'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { isPathMatchesAlias, resolveAlias, reset, addAlias, addAliases } from '../../esm-loader.mjs'
+
+const { expect } = chai
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+describe('ESM Loader', function () {
+  describe('isPathMatchesAlias', function () {
+    it('should match exact alias', function () {
+      expect(isPathMatchesAlias('@lib', '@lib')).to.equal(true)
+    })
+
+    it('should match alias with subpath', function () {
+      expect(isPathMatchesAlias('@lib/foo', '@lib')).to.equal(true)
+      expect(isPathMatchesAlias('@lib/foo/bar', '@lib')).to.equal(true)
+    })
+
+    it('should reject partial prefix match', function () {
+      expect(isPathMatchesAlias('@library', '@lib')).to.equal(false)
+      expect(isPathMatchesAlias('@lib-utils', '@lib')).to.equal(false)
+    })
+
+    it('should match non-scoped aliases', function () {
+      expect(isPathMatchesAlias('src/foo', 'src')).to.equal(true)
+      expect(isPathMatchesAlias('src', 'src')).to.equal(true)
+    })
+
+    it('should reject non-matching paths', function () {
+      expect(isPathMatchesAlias('other/path', '@lib')).to.equal(false)
+      expect(isPathMatchesAlias('', '@lib')).to.equal(false)
+    })
+  })
+
+  describe('resolveAlias', function () {
+    afterEach(function () {
+      reset()
+    })
+
+    it('should resolve alias to path', function () {
+      const targetPath = path.join(__dirname, '../src')
+      addAlias('@src', targetPath)
+
+      const result = resolveAlias('@src/foo')
+      expect(result).to.equal(path.join(targetPath, '/foo'))
+    })
+
+    it('should resolve exact alias match', function () {
+      const targetPath = path.join(__dirname, '../src/foo/index.js')
+      addAlias('@foo', targetPath)
+
+      const result = resolveAlias('@foo')
+      expect(result).to.equal(targetPath)
+    })
+
+    it('should return null for non-aliased specifier', function () {
+      addAlias('@src', '/some/path')
+
+      const result = resolveAlias('other-module')
+      expect(result).to.equal(null)
+    })
+
+    it('should return null for node_modules specifier', function () {
+      addAlias('@src', '/some/path')
+
+      const result = resolveAlias('lodash')
+      expect(result).to.equal(null)
+    })
+
+    it('should match longest alias first', function () {
+      addAliases({
+        'react-dom': '/path/to/react-dom',
+        'react-dom/server': '/path/to/server'
+      })
+
+      const result = resolveAlias('react-dom/server')
+      expect(result).to.equal('/path/to/server')
+    })
+
+    it('should handle multiple aliases', function () {
+      addAliases({
+        '@lib': '/path/to/lib',
+        '@utils': '/path/to/utils'
+      })
+
+      expect(resolveAlias('@lib/foo')).to.equal('/path/to/lib/foo')
+      expect(resolveAlias('@utils/bar')).to.equal('/path/to/utils/bar')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add native ES module support using Node.js loader hooks API
- Support `_moduleAliases` and `_moduleDirectories` from package.json in ESM
- Automatic version detection: `registerHooks()` for Node 22.15+, `register()` for Node 18.19+
- Full backward compatibility with existing CJS usage

## Usage

```bash
node --import module-alias/register ./app.mjs
```

## Changes

- `register.mjs` - ESM entry point with version detection
- `esm-loader.mjs` - Core resolve hooks implementation
- `package.json` - Added `exports` field for dual CJS/ESM support
- `README.md` - ESM documentation section
- `.github/workflows/node.js.yml` - CI for Node 18/20/22

## Test Plan

- [x] Unit tests for `isPathMatchesAlias` and `resolveAlias` (11 tests)
- [x] Integration tests spawning node with `--import` flag (2 tests)
- [x] Tested on Node 18, 20, 22, 24
- [x] CJS backward compatibility verified (20 existing tests pass)
- [x] POC app tested with `_moduleAliases` and `_moduleDirectories`

Closes #59
Closes #113